### PR TITLE
chore: add wave 2 PR workflow gates

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: dependency-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    steps:
+      - name: dependency-review-private-skip
+        if: ${{ github.event.repository.private }}
+        run: echo "Dependency review is skipped on private repositories unless GitHub Advanced Security is enabled."
+      - name: dependency-review
+        if: ${{ !github.event.repository.private }}
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/linked-issue.yml
+++ b/.github/workflows/linked-issue.yml
@@ -1,0 +1,65 @@
+name: linked-issue
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: linked-issue-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-linked-issue:
+    name: check-linked-issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-linked-issue
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+
+          with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+              event = json.load(handle)
+
+          pull_request = event["pull_request"]
+          title = (pull_request.get("title") or "").strip()
+          body = pull_request.get("body") or ""
+          author = ((pull_request.get("user") or {}).get("login") or "").strip()
+          labels = {
+              label.get("name")
+              for label in pull_request.get("labels", [])
+              if label.get("name")
+          }
+
+          if author in {"dependabot[bot]", "renovate[bot]", "github-actions[bot]"}:
+              print(f"Skipping linked issue enforcement for bot author {author}.")
+              sys.exit(0)
+
+          if "no-linked-issue-required" in labels:
+              print("Bypass label no-linked-issue-required is present.")
+              sys.exit(0)
+
+          text = "\n".join(part for part in (title, body) if part)
+          patterns = (
+              re.compile(r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|ref(?:erence)?s?|see)\s*:?\s+(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#\d+\b"),
+              re.compile(r"(?i)https://github\.com/[^/\s]+/[^/\s]+/issues/\d+\b"),
+              re.compile(r"(?<![/\w])#\d+\b"),
+          )
+
+          if any(pattern.search(text) for pattern in patterns):
+              print("Issue reference found in PR title/body.")
+              sys.exit(0)
+
+          print(
+              '::error title=Linked issue required::Add an issue reference to the PR title or body (for example, "Closes #123" or "#123"), or apply the "no-linked-issue-required" label.'
+          )
+          sys.exit(1)
+          PY

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,49 @@
+name: pr-title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    name: pr-title
+    runs-on: ubuntu-latest
+    steps:
+      - name: pr-title
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+
+          with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+              event = json.load(handle)
+
+          title = (event["pull_request"].get("title") or "").strip()
+          if not title:
+              print("::error title=PR title required::PR title cannot be empty.")
+              sys.exit(1)
+
+          blocked_patterns = (
+              re.compile(r"(?i)^\s*\[?\s*wip\b"),
+              re.compile(r"(?i)^\s*\[?\s*draft\b"),
+              re.compile(r"(?i)^\s*(?:do not merge|dnm)\b"),
+          )
+          if any(pattern.search(title) for pattern in blocked_patterns):
+              print(
+                  '::error title=Invalid PR title::Use a descriptive title and avoid empty, WIP, draft, or do-not-merge titles.'
+              )
+              sys.exit(1)
+
+          print(f"PR title is valid: {title}")
+          PY


### PR DESCRIPTION
Closes #16

## Summary
- add the standardized dependency review workflow
- add the standardized linked-issue workflow
- add the standardized PR-title workflow
- add cancel-in-progress concurrency on the new PR workflows

## Validation
- validated workflow YAML with ConvertFrom-Yaml
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/test-sandbox/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
